### PR TITLE
feat: instrument the oak-segment-tar package

### DIFF
--- a/oak-segment-tar/build.gradle
+++ b/oak-segment-tar/build.gradle
@@ -11,6 +11,7 @@ dependencies {
    implementation 'com.newrelic.agent.java:newrelic-api:6.4.0'
    implementation fileTree(include: ['*.jar'], dir: '../libs')
    implementation fileTree(include: ['*.jar'], dir: '../test-lib')
+    implementation project(":common")
 }
 
 jar {
@@ -28,4 +29,5 @@ verifyInstrumentation {
   // Example:
   // passes 'javax.servlet:servlet-api:[2.2,2.5]'
   // exclude 'javax.servlet:servlet-api:2.4.public_draft'
+    passes 'org.apache.jackrabbit:oak-segment-tar:[1.10.0]'
 }

--- a/oak-segment-tar/src/main/java/com/newrelic/instrumentation/labs/Constants.java
+++ b/oak-segment-tar/src/main/java/com/newrelic/instrumentation/labs/Constants.java
@@ -1,0 +1,119 @@
+package com.newrelic.instrumentation.labs;
+
+import org.apache.jackrabbit.oak.backup.FileStoreBackup;
+import org.apache.jackrabbit.oak.backup.FileStoreRestore;
+import org.apache.jackrabbit.oak.segment.Cache;
+
+public interface Constants {
+	String FILE_STORE_BACKUP_CLASS_NAME = FileStoreBackup.class.getSimpleName();
+	String FILE_STORE_RESTORE_CLASS_NAME = FileStoreRestore.class.getSimpleName();
+	String SEGMENT_CACHE_CLASS_NAME = Cache.class.getSimpleName();
+	// WriteOperationHandler and WriterOperation hav package visibility, so they
+	// can't be imported. The class names must be hardcoded instead.
+	String WRITE_OPERATION_HANDLER_CLASS_NAME = "WriteOperationHandler";
+	String WRITE_OPERATION_CLASS_NAME = "WriteOperation";
+
+	String[] BACKUP_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Backup",
+		FILE_STORE_BACKUP_CLASS_NAME,
+		"backup"
+	};
+
+	String OAK_BACKUP_REVISIONS_HEAD_RECORD_ID
+		= "oakBackupRevisionsHeadRecordId";
+	String OAK_BACKUP_REVISIONS_PERSISTED_HEAD_RECORD_ID
+		= "oakBackupRevisionsPersistedHeadRecordId";
+	String OAK_BACKUP_DESTINATION_PATH = "oakBackupDestinationPath";
+
+	String[] CLEANUP_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Backup",
+		FILE_STORE_BACKUP_CLASS_NAME,
+		"cleanup"
+	};
+
+	String OAK_CLEANUP_FILE_STORE_APPROX_SIZE
+		= "oakCleanupFileStoreApproximateSize";
+	String OAK_CLEANUP_FILE_STORE_SEGMENT_COUNT
+		= "oakCleanupFileStoreSegmentCount";
+	String OAK_CLEANUP_FILE_STORE_TAR_FILE_COUNT
+		= "oakCleanupFileStoreTarFileCount";
+	String OAK_CLEANUP_FILE_STORE_READER_COUNT
+		= "oakCleanupFileStoreReaderCount";
+
+	String[] RESTORE_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Backup",
+		FILE_STORE_RESTORE_CLASS_NAME,
+		"restore"
+	};
+
+	String OAK_RESTORE_SOURCE_PATH
+		= "oakRestoreSourcePath";
+	String OAK_RESTORE_DESTINATION_PATH
+		= "oakRestoreDestinationPath";
+
+	String[] CACHE_GET_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Segment",
+		SEGMENT_CACHE_CLASS_NAME,
+		"get"
+	};
+
+	String OAK_CACHE_GET_KEY = "oakCacheGetKey";
+
+	String[] CACHE_PUT_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Segment",
+		SEGMENT_CACHE_CLASS_NAME,
+		"put"
+	};
+
+	String OAK_CACHE_PUT_KEY = "oakCachePutKey";
+	String OAK_CACHE_PUT_COST = "oakCachePutCost";
+
+	String[] WRITE_OPERATION_HANDLER_EXECUTE_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Segment",
+		WRITE_OPERATION_HANDLER_CLASS_NAME,
+		"execute"
+	};
+
+	String OAK_WRITE_OP_HANDLER_EXECUTE_GC_GEN = "oakWriteOperationGcGen";
+	String OAK_WRITE_OP_HANDLER_EXECUTE_GC_FULL_GEN
+		= "oakWriteOperationGcFullGen";
+	String OAK_WRITE_OP_HANDLER_EXECUTE_GC_IS_COMPACTED
+		= "oakWriteOperationGcIsCompacted";
+
+	String[] WRITE_OPERATION_HANDLER_FLUSH_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Segment",
+		WRITE_OPERATION_HANDLER_CLASS_NAME,
+		"flush"
+	};
+
+	String[] WRITE_OPERATION_EXECUTE_METRIC_NAME = new String[] {
+		"Custom",
+		"JackRabbit",
+		"Oak",
+		"Segment",
+		WRITE_OPERATION_HANDLER_CLASS_NAME,
+		WRITE_OPERATION_CLASS_NAME,
+		"execute"
+	};
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/backup/FileStoreBackup.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/backup/FileStoreBackup.java
@@ -1,0 +1,103 @@
+package org.apache.jackrabbit.oak.backup;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.instrumentation.labs.Constants;
+import com.newrelic.instrumentation.labs.Instrument;
+import org.apache.jackrabbit.oak.segment.Revisions;
+import org.apache.jackrabbit.oak.segment.SegmentReader;
+import org.apache.jackrabbit.oak.segment.file.FileStore;
+import org.apache.jackrabbit.oak.segment.file.FileStoreStats;
+import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
+
+import java.io.File;
+import java.io.IOException;
+
+@Weave(type = MatchType.Interface)
+public class FileStoreBackup {
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace(dispatcher = true)
+	public void backup(
+		SegmentReader reader,
+		Revisions revisions,
+		File destination
+	) {
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.BACKUP_METRIC_NAME)
+			.attr(
+				Constants.OAK_BACKUP_REVISIONS_HEAD_RECORD_ID,
+				revisions.getHead().asUUID().toString()
+			)
+			.attr(
+				Constants.OAK_BACKUP_REVISIONS_PERSISTED_HEAD_RECORD_ID,
+				revisions.getPersistedHead().asUUID().toString()
+			)
+			.attr(
+				Constants.OAK_BACKUP_DESTINATION_PATH,
+				destination.getAbsolutePath()
+			)
+			.record();
+
+		try {
+			Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			//noinspection ConstantValue
+			if (e instanceof InvalidFileStoreVersionException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+
+	@Trace(dispatcher = true)
+	public boolean cleanup(FileStore f) {
+		Instrument instrument = new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.CLEANUP_METRIC_NAME)
+			.attr(
+				Constants.OAK_CLEANUP_FILE_STORE_READER_COUNT,
+				f.readerCount()
+			);
+		FileStoreStats stats = f.getStats();
+
+		if (stats != null) {
+			instrument.attr(
+				Constants.OAK_CLEANUP_FILE_STORE_APPROX_SIZE,
+				stats.getApproximateSize()
+			)
+				.attr(
+					Constants.OAK_CLEANUP_FILE_STORE_SEGMENT_COUNT,
+					stats.getSegmentCount()
+				)
+				.attr(
+					Constants.OAK_CLEANUP_FILE_STORE_TAR_FILE_COUNT,
+					stats.getTarFileCount()
+				);
+		}
+
+		instrument.record();
+
+		try {
+			return Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/backup/FileStoreRestore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/backup/FileStoreRestore.java
@@ -1,0 +1,66 @@
+package org.apache.jackrabbit.oak.backup;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.instrumentation.labs.Constants;
+import com.newrelic.instrumentation.labs.Instrument;
+import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
+
+import java.io.File;
+import java.io.IOException;
+
+@Weave(type = MatchType.Interface)
+public class FileStoreRestore {
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace(dispatcher = true)
+	public void restore(File source) {
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.RESTORE_METRIC_NAME)
+			.attr(
+				Constants.OAK_RESTORE_SOURCE_PATH,
+				source.getAbsolutePath()
+			)
+			.record();
+
+		Weaver.callOriginal();
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace(dispatcher = true)
+	public void restore(File source, File destination) {
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.RESTORE_METRIC_NAME)
+			.attr(
+				Constants.OAK_RESTORE_SOURCE_PATH,
+				source.getAbsolutePath()
+			)
+			.attr(
+				Constants.OAK_RESTORE_DESTINATION_PATH,
+				destination.getAbsolutePath()
+			)
+			.record();
+
+		try {
+			Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			//noinspection ConstantValue
+			if (e instanceof InvalidFileStoreVersionException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Cache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Cache.java
@@ -1,0 +1,52 @@
+package org.apache.jackrabbit.oak.segment;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.instrumentation.labs.Constants;
+import com.newrelic.instrumentation.labs.Instrument;
+
+@Weave(type = MatchType.Interface)
+public class Cache<K,V> {
+	@Trace
+	public V get(K key){
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.CACHE_GET_METRIC_NAME)
+			.attr(Constants.OAK_CACHE_GET_KEY, key.toString())
+			.record();
+
+		return Weaver.callOriginal();
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace
+	public void put(K key, V value){
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.CACHE_PUT_METRIC_NAME)
+			.attr(Constants.OAK_CACHE_PUT_KEY, key.toString())
+			.record();
+
+		Weaver.callOriginal();
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace
+	public void put(K key, V value, byte cost){
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.CACHE_PUT_METRIC_NAME)
+			.attr(Constants.OAK_CACHE_PUT_KEY, key.toString())
+			.attr(Constants.OAK_CACHE_PUT_COST, Byte.valueOf(cost).intValue())
+			.record();
+
+		Weaver.callOriginal();
+	}
+
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperationHandler_Weaved.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperationHandler_Weaved.java
@@ -1,0 +1,72 @@
+package org.apache.jackrabbit.oak.segment;
+
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.instrumentation.labs.Constants;
+import com.newrelic.instrumentation.labs.Instrument;
+import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
+
+import java.io.IOException;
+
+@Weave(
+	originalName = "org.apache.jackrabbit.oak.segment.WriteOperationHandler",
+	type = MatchType.Interface
+)
+class WriteOperationHandler_Weaved {
+	@Trace(dispatcher = true)
+	public RecordId execute(
+		GCGeneration gcGeneration,
+		WriteOperationHandler.WriteOperation writeOperation
+	) {
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.WRITE_OPERATION_HANDLER_EXECUTE_METRIC_NAME)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_GEN,
+				gcGeneration.getGeneration()
+			)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_FULL_GEN,
+				gcGeneration.getFullGeneration()
+			)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_IS_COMPACTED,
+				gcGeneration.isCompacted()
+			)
+			.record();
+
+		try {
+			return Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Trace(dispatcher = true)
+	public void flush(SegmentStore store) {
+		new Instrument(NewRelic.getAgent().getTracedMethod())
+			.name(Constants.WRITE_OPERATION_HANDLER_FLUSH_METRIC_NAME)
+			.record();
+
+		try {
+			Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperation_Weaved.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperation_Weaved.java
@@ -1,0 +1,52 @@
+import com.newrelic.api.agent.NewRelic;
+import com.newrelic.api.agent.Trace;
+import com.newrelic.api.agent.weaver.MatchType;
+import com.newrelic.api.agent.weaver.Weave;
+import com.newrelic.api.agent.weaver.Weaver;
+import com.newrelic.instrumentation.labs.Constants;
+import com.newrelic.instrumentation.labs.Instrument;
+import org.apache.jackrabbit.oak.segment.RecordId;
+import org.apache.jackrabbit.oak.segment.SegmentBufferWriter;
+import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
+
+import java.io.IOException;
+
+@Weave(
+	originalName = "org.apache.jackrabbit.oak.segment.WriteOperationHandler$WriteOperation",
+	type = MatchType.Interface
+)
+public class WriteOperation_Weaved {
+	@Trace(dispatcher = true)
+	public RecordId execute(SegmentBufferWriter writer) {
+		GCGeneration gcGeneration = writer.getGCGeneration();
+
+		new Instrument(
+			NewRelic.getAgent().getTracedMethod()
+		)
+			.name(Constants.WRITE_OPERATION_EXECUTE_METRIC_NAME)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_GEN,
+				gcGeneration.getGeneration()
+			)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_FULL_GEN,
+				gcGeneration.getFullGeneration()
+			)
+			.attr(
+				Constants.OAK_WRITE_OP_HANDLER_EXECUTE_GC_IS_COMPACTED,
+				gcGeneration.isCompacted()
+			)
+			.record();
+
+		try {
+			return Weaver.callOriginal();
+		} catch (Exception e) {
+			//noinspection ConstantValue
+			if (e instanceof IOException) {
+				NewRelic.noticeError(e);
+			}
+
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
## Adds
* Instrumentation for the [`FileStoreBackup`](https://www.javadoc.io/static/org.apache.jackrabbit/oak-segment-tar/1.10.0/org/apache/jackrabbit/oak/backup/FileStoreBackup.html) and [`FileStoreRestore`](https://www.javadoc.io/static/org.apache.jackrabbit/oak-segment-tar/1.10.0/org/apache/jackrabbit/oak/backup/FileStoreRestore.html) interfaces
* Instrumentation for the segment [`Cache`](https://www.javadoc.io/static/org.apache.jackrabbit/oak-segment-tar/1.10.0/org/apache/jackrabbit/oak/segment/Cache.html) interface
* Instrumentation for the package level [`WriteOperationHandler`](https://github.com/apache/jackrabbit-oak/blob/jackrabbit-oak-1.10.0/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperationHandler.java) interface and it's inner interface `WriteOperation`